### PR TITLE
Fix preview lines rendering on single line

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1514,10 +1514,16 @@ async function buildFileItemsWithPreview(fileList: string[], previewLines: numbe
     const fileDir = path.dirname(relativePath);
     const preview = await getFilePreview(file, previewLines);
     
+    // Format preview for QuickPick (VSCode doesn't support multiline in detail field)
+    const previewLinesArray = preview.split('\n');
+    const formattedPreview = previewLinesArray.length > 1 
+      ? `${previewLinesArray[0]} (${previewLinesArray.length} lines total)`
+      : preview;
+    
     return {
       label: fileName,
       description: fileDir === '.' ? '' : fileDir,
-      detail: preview.length > 100 ? preview.substring(0, 100) + '...' : preview,
+      detail: formattedPreview.length > 100 ? formattedPreview.substring(0, 100) + '...' : formattedPreview,
       filePath: file,
       preview: preview
     };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1714,10 +1714,10 @@ function getTelescopeWebviewContent(items: TelescopeWebviewItem[], selectedIndex
                 return;
             }
             
-                         const lines = item.preview.split('\\\\n');
-             previewContent.innerHTML = lines.map((line, i) => 
-                 \`<div class="preview-line"><span class="line-number">\${i + 1}</span>\${line || ' '}</div>\`
-             ).join('');
+            const lines = item.preview.split('\\n');
+            previewContent.innerHTML = lines.map((line, i) => 
+                \`<div class="preview-line"><span class="line-number">\${i + 1}</span>\${line || ' '}</div>\`
+            ).join('');
         }
         
         function updateFileList() {


### PR DESCRIPTION
Fixes preview lines rendering as a single line by correcting the newline split character in the JavaScript update function.

---

[Open in Web](https://cursor.com/agents?id=bc-bb394260-943c-4e41-88b9-8b1956ad209a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bb394260-943c-4e41-88b9-8b1956ad209a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)